### PR TITLE
Rethrow exception when no response exists

### DIFF
--- a/src/DRC/RESTClient.cs
+++ b/src/DRC/RESTClient.cs
@@ -366,8 +366,13 @@
             try
             {
                 resp = wr.GetResponse();
-            }catch(WebException e)
+            }
+            catch(WebException e)
             {
+                // rethrow exception when no response exists
+                if (e.Response == null) 
+                    throw e;
+                // otherwise return response contained in exception
                 resp = e.Response;
             }
             // ReSharper restore EmptyGeneralCatchClause


### PR DESCRIPTION
Prevents nullReferenceException further down the line.
